### PR TITLE
Fix wrong value for manifest version

### DIFF
--- a/src/templates/manifest.js
+++ b/src/templates/manifest.js
@@ -15,7 +15,7 @@ export default ({
   extensions
 }) => {
   return `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<ExtensionManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ExtensionBundleId="${bundleId}" ExtensionBundleName="${bundleName}" ExtensionBundleVersion="${bundleVersion}" Version="${cepVersion}">
+<ExtensionManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ExtensionBundleId="${bundleId}" ExtensionBundleName="${bundleName}" ExtensionBundleVersion="${bundleVersion}" Version="7.0">
   <ExtensionList>
     ${extensions.map(extension => `<Extension Id="${extension.id}" Version="${bundleVersion}" />`).join('\n    ')}
   </ExtensionList>


### PR DESCRIPTION
The documentation (https://github.com/Adobe-CEP/CEP-Resources/blob/master/CEP_8.x/ExtensionManifest_v_7_0.xsd#L521) says that this field is the manifest version. Not that of the CSInterface.